### PR TITLE
Fix `_base_cmaskcar` destructor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
           - '3.12'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -27,5 +27,5 @@ jobs:
       - name: Running flake8
         run: flake8 vsmasktools
       - name: Running mypy
-        if: steps.dependencies.outcome == 'success'
         run: mypy vsmasktools
+        continue-on-error: true

--- a/vsmasktools/hardsub.py
+++ b/vsmasktools/hardsub.py
@@ -46,8 +46,6 @@ class _base_cmaskcar(vs_object):
         ...
 
     def __vs_del__(self, core_id: int) -> None:
-        super().__vs_del__(core_id)
-
         self.clips.clear()
 
 


### PR DESCRIPTION
Given the following minimal script:

```python
from vsmasktools import CustomMaskFromRanges
from vstools import core, set_output

mask = CustomMaskFromRanges(ranges={})
set_output(core.std.BlankClip())
```

Opening this in vs-preview and then closing the program yields the
following error:

```
Traceback (most recent call last):
  File "vstools/utils/vs_proxy.py", line 351, in _finalize_core
    callback(env_id, core_id)
TypeError: _base_cmaskcar.__vs_del__() takes 2 positional arguments but 4 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "Lib/weakref.py", line 666, in _exitfunc
    f()
  File "Lib/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "vstools/utils/vs_proxy.py", line 384, in <lambda>
    weakref.finalize(_vs_core, lambda: _finalize_core(env_id, core_id, False))
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "vstools/utils/vs_proxy.py", line 353, in _finalize_core
    callback()
  File "vsmasktools/hardsub.py", line 50, in __vs_del__
    super().__vs_del__(core_id)
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute '__vs_del__'
```

AFAICT there isn't actually a `super().__vs_del__()` to call (this only
inherits from `vs_object`), and none of the other examples of
`__vs_del__()` throughout JET have this pattern, so this patch removes
it.

---

Also reenabled mypy in CI, but not gonna clutter this PR with fixing the
existing issues, so ignoring failures for now.


