### PR TITLE
Allow squaremask to not necessarily be gray

### DIFF
--- a/vsmasktools/abstract.py
+++ b/vsmasktools/abstract.py
@@ -37,7 +37,7 @@ class BoundingBox(GeneralMask):
 
     def get_mask(self, ref: vs.VideoNode, *args: Any, **kwargs: Any) -> vs.VideoNode:  # type: ignore[override]
         from .utils import squaremask
-        return squaremask(ref, self.size.x, self.size.y, self.pos.x, self.pos.y, self.invert, self.get_mask)
+        return squaremask(ref, self.size.x, self.size.y, self.pos.x, self.pos.y, self.invert, False, self.get_mask)
 
 
 class DeferredMask(GeneralMask):


### PR DESCRIPTION
Also fixes the uses of DeferredMask and its subclasses when using BoudingBox [here](https://github.com/Varde-s-Forks/vs-masktools/blob/d5ab65ee5262417f79b389ab303c1b7bfc0d5478/vsmasktools/abstract.py#L101) and when passing YUV clip in [`get_mask`](https://github.com/Varde-s-Forks/vs-masktools/blob/d5ab65ee5262417f79b389ab303c1b7bfc0d5478/vsmasktools/abstract.py#L67) function.