### PR TITLE
Fix ridgemask

### DIFF
--- a/vsmasktools/edge/_1d.py
+++ b/vsmasktools/edge/_1d.py
@@ -149,7 +149,7 @@ class SavitzkyGolayNormalise(SavitzkyGolay):
     def _preprocess(self, clip: vs.VideoNode) -> vs.VideoNode:
         return depth(clip, 32)
 
-    def _postprocess(self, clip: vs.VideoNode, input_bits: int) -> vs.VideoNode:
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
         return depth(clip, input_bits, range_in=ColorRange.FULL, range_out=ColorRange.FULL)
 
     def _get_matrices(self) -> Sequence[Sequence[float]]:

--- a/vsmasktools/edge/_3x3.py
+++ b/vsmasktools/edge/_3x3.py
@@ -239,7 +239,7 @@ class FreyChen(MatrixEdgeDetect):
     def _preprocess(self, clip: vs.VideoNode) -> vs.VideoNode:
         return depth(clip, 32)
 
-    def _postprocess(self, clip: vs.VideoNode, input_bits: int) -> vs.VideoNode:
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
         return depth(clip, input_bits, range_in=ColorRange.FULL, range_out=ColorRange.FULL)
 
     def _merge_edge(self, clips: Sequence[vs.VideoNode]) -> vs.VideoNode:

--- a/vsmasktools/edge/_5x5.py
+++ b/vsmasktools/edge/_5x5.py
@@ -106,7 +106,7 @@ class DoG(EuclideanDistance, Matrix5x5):
     def _preprocess(self, clip: vs.VideoNode) -> vs.VideoNode:
         return depth(clip, 32)
 
-    def _postprocess(self, clip: vs.VideoNode, input_bits: int) -> vs.VideoNode:
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
         return depth(clip, input_bits, range_out=ColorRange.FULL, range_in=ColorRange.FULL)
 
     def _merge_edge(self, clips: Sequence[vs.VideoNode]) -> vs.VideoNode:
@@ -133,7 +133,7 @@ class Farid(RidgeDetect, EuclideanDistance, Matrix5x5):
     def _preprocess(self, clip: vs.VideoNode) -> vs.VideoNode:
         return depth(clip, 32)
 
-    def _postprocess(self, clip: vs.VideoNode, input_bits: int) -> vs.VideoNode:
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
         return depth(clip, input_bits, range_out=ColorRange.FULL, range_in=ColorRange.FULL)
 
 

--- a/vsmasktools/edge/_abstract.py
+++ b/vsmasktools/edge/_abstract.py
@@ -7,9 +7,9 @@ from typing import Any, ClassVar, NoReturn, Sequence, TypeAlias
 from stgpytools import inject_kwargs_params
 from vsexprtools import ExprOp, ExprToken, norm_expr
 from vstools import (
-    ColorRange, CustomRuntimeError, CustomValueError, FuncExceptT, KwargsT, PlanesT, T, check_variable, core,
-    get_lowest_values, get_peak_value, get_peak_values, get_subclasses, inject_self, join, normalize_planes, plane,
-    scale_mask, vs
+    ColorRange, CustomRuntimeError, CustomValueError, DitherType, FuncExceptT, KwargsT, PlanesT, T,
+    check_variable, core, depth, get_lowest_values, get_peak_value, get_peak_values, get_subclasses,
+    inject_self, join, normalize_planes, plane, scale_mask, vs
 )
 
 from ..exceptions import UnknownEdgeDetectError, UnknownRidgeDetectError
@@ -244,7 +244,7 @@ class EdgeDetect(ABC):
     def _preprocess(self, clip: vs.VideoNode) -> vs.VideoNode:
         return clip
 
-    def _postprocess(self, clip: vs.VideoNode, input_bits: int) -> vs.VideoNode:
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
         return clip
 
 
@@ -290,7 +290,7 @@ class MatrixEdgeDetect(EdgeDetect):
     def _get_mode_types(self) -> Sequence[str]:
         return self.mode_types if self.mode_types else ['s'] * len(self._get_matrices())
 
-    def _postprocess(self, clip: vs.VideoNode, input_bits: int) -> vs.VideoNode:
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
         if len(self.matrices[0]) > 9 or (self.mode_types and self.mode_types[0] != 's'):
             clip = clip.std.Crop(
                 right=clip.format.subsampling_w * 2 if clip.format and clip.format.subsampling_w != 0 else 2
@@ -326,10 +326,11 @@ class RidgeDetect(MatrixEdgeDetect):
         self, clip: vs.VideoNode, lthr: float = 0.0, hthr: float | None = None, multi: float = 1.0,
         clamp: bool | tuple[float, float] | list[tuple[float, float]] = False,
         planes: PlanesT | tuple[PlanesT, bool] = None, **kwargs: Any
-    ) -> vs.VideoNode | NoReturn:
+    ) -> vs.VideoNode:
         """
         Makes ridge mask based on convolution kernel.
         The resulting mask can be thresholded with lthr, hthr and multiplied with multi.
+        Using a 32-bit float clip is recommended.
 
         :param clip:            Source clip
         :param lthr:            Low threshold. Anything below lthr will be set to 0
@@ -343,6 +344,20 @@ class RidgeDetect(MatrixEdgeDetect):
 
     def _merge_ridge(self, clips: Sequence[vs.VideoNode]) -> vs.VideoNode:
         return core.std.Expr(clips, 'x 2 pow z 2 pow 4 * + x y * 2 * - y 2 pow + sqrt x y + + 0.5 *')
+
+    def _preprocess(self, clip: vs.VideoNode) -> vs.VideoNode:
+        if len(self.matrices[0]) > 9 or (self.mode_types and self.mode_types[0] != 's'):
+            clip = clip.resize.Point(clip.width + 4, src_width=clip.width + 4)
+
+        return super()._preprocess(depth(clip, 32))
+
+    def _postprocess(self, clip: vs.VideoNode, input_bits: int | None = None) -> vs.VideoNode:
+        clip = depth(clip, input_bits, dither_type=DitherType.NONE)
+
+        if len(self.matrices[0]) > 9 or (self.mode_types and self.mode_types[0] != 's'):
+            return clip.std.Crop(right=4)
+
+        return super()._postprocess(clip, input_bits)
 
 
 class SingleMatrix(MatrixEdgeDetect, ABC):

--- a/vsmasktools/edge/_abstract.py
+++ b/vsmasktools/edge/_abstract.py
@@ -270,7 +270,7 @@ class MatrixEdgeDetect(EdgeDetect):
         y = _y(clip)
         xx = _x(x)
         yy = _y(y)
-        xy = _x(x)
+        xy = _y(x)
         return self._merge_ridge([xx, yy, xy])
 
     @abstractmethod

--- a/vsmasktools/edge/_abstract.py
+++ b/vsmasktools/edge/_abstract.py
@@ -342,7 +342,7 @@ class RidgeDetect(MatrixEdgeDetect):
         return self._mask(clip, lthr, hthr, multi, clamp, _Feature.RIDGE, planes, **kwargs)
 
     def _merge_ridge(self, clips: Sequence[vs.VideoNode]) -> vs.VideoNode:
-        return core.std.Expr(clips, 'x y * 2 * -1 * x dup * z dup * 4 * + y dup * + + sqrt x y + +')
+        return core.std.Expr(clips, 'x 2 pow z 2 pow 4 * + x y * 2 * - y 2 pow + sqrt x y + + 0.5 *')
 
 
 class SingleMatrix(MatrixEdgeDetect, ABC):


### PR DESCRIPTION
- Integer clips have wrong output so the processing is now always in 32-bit float
- xy derivative was wrong (it didn't affect the output much)
- The expr was missing a 0.5 factor. Output will be different and is a breaking change.
- 5x5 convolutions need a right border fix. Technically, we only need 2 pixels but you'd have to fix each derivative and it slows down the process by quite a bit. Adding a 4 px mirror border and cropping it at the end is close enough.