### PR TITLE
speedup adg_mask for integer formats

### DIFF
--- a/vsmasktools/spat_funcs.py
+++ b/vsmasktools/spat_funcs.py
@@ -42,17 +42,19 @@ def adg_mask(
 
     assert check_variable(clip, func)
 
-    luma, prop = plane(clip, 0), 'P' if complexpr_available else None
+    use_complex = complexpr_available and clip.format.bits_per_sample > 16
+
+    luma, prop = plane(clip, 0), 'P' if use_complex else None
     y, y_inv = luma.std.PlaneStats(prop=prop), luma.std.Invert().std.PlaneStats(prop=prop)
 
-    if not complexpr_available and relative:
+    if not use_complex and relative:
         raise CustomRuntimeError(
             "You don't have akarin plugin, you can't use this function!", func, 'relative=True'
         )
 
     assert y.format
 
-    if complexpr_available:
+    if use_complex:
         peak = get_peak_value(y)
 
         is_integer = y.format.sample_type == vs.INTEGER


### PR DESCRIPTION
complexpr is only faster for 32-bit formats

before:

```
Resolution: 3840x2160

Format: GRAY16
Function    Params    Time [min, max]    FPS [min, max]             Relative
----------  --------  -----------------  -----------------------  ----------
adg plugin  {}        0.85 [0.82, 0.87]  282.84 [274.67, 293.60]        1
adg expr    {}        3.45 [3.42, 3.47]  69.52 [69.19, 70.09]           0.25
```

with this change

```
Resolution: 3840x2160

Format: GRAY16
Function    Params    Time [min, max]    FPS [min, max]             Relative
----------  --------  -----------------  -----------------------  ----------
adg plugin  {}        0.85 [0.82, 0.88]  282.00 [273.88, 293.65]        0.99
adg expr    {}        0.84 [0.83, 0.86]  284.28 [277.59, 288.64]        1
```