### PR TITLE
Fix bound mask not working

### DIFF
--- a/vsmasktools/abstract.py
+++ b/vsmasktools/abstract.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Sequence
 
-from vsexprtools import ExprOp, norm_expr
+from vsexprtools import ExprOp
 from vsrgtools import box_blur
 from vstools import (
     ColorRange, FrameRangeN, FrameRangesN, FramesLengthError, Position, Size,
@@ -99,7 +99,7 @@ class DeferredMask(GeneralMask):
             if self.blur:
                 bm = box_blur(bm, 5, 5)
 
-            return norm_expr([hm, bm], f'y {ExprOp.clamp(c="x")} 0 ?')
+            hm = hm.std.BlankClip(keep=True).std.MaskedMerge(hm, bm)
 
         return hm.std.Limiter()
 

--- a/vsmasktools/utils.py
+++ b/vsmasktools/utils.py
@@ -120,7 +120,7 @@ def squaremask(
     if complexpr_available:
         base_clip = clip.std.BlankClip(
             None, None, mask_format.id, 1,
-            color=get_lowest_values(mask_format),
+            color=get_lowest_values(mask_format, ColorRange.FULL),
             keep=True
         )
         exprs = [
@@ -146,7 +146,9 @@ def squaremask(
 
         mask = norm_expr(base_clip, tuple(exprs), force_akarin=func)
     else:
-        base_clip = clip.std.BlankClip(width, height, mask_format.id, 1, color=get_peak_values(mask_format), keep=True)
+        base_clip = clip.std.BlankClip(
+            width, height, mask_format.id, 1, color=get_peak_values(mask_format, ColorRange.FULL), keep=True
+        )
 
         mask = base_clip.std.AddBorders(
             offset_x, clip.width - width - offset_x, offset_y, clip.height - height - offset_y,


### PR DESCRIPTION
Lowest value was assuming limited range so the expr was always returning true.
Also, switching to MaskedMerge making `blur` actually useful.