### PR TITLE
Use ConvMode.SQUARE in morpho_xx_inum

### DIFF
--- a/vsmasktools/morpho.py
+++ b/vsmasktools/morpho.py
@@ -90,7 +90,7 @@ class Morpho:
             if isinstance(coords, tuple):
                 size, mode = coords
             else:
-                size, mode = coords, ConvMode.HV
+                size, mode = coords, ConvMode.SQUARE
 
             assert size > 1
 
@@ -102,7 +102,7 @@ class Morpho:
         else:
             coords = list(coords)
             coords.insert(len(coords) // 2, 1)
-            radius, mode = floor(sqrt(len(coords)) / 2), ConvMode.HV
+            radius, mode = floor(sqrt(len(coords)) / 2), ConvMode.SQUARE
 
         matrix = ExprOp.matrix('x', radius, mode, exclude)
 


### PR DESCRIPTION
In https://github.com/Jaded-Encoding-Thaumaturgy/vs-exprtools/commit/43824949a1cb9ce6d4c35e77141b8ded7ab596d9, the behavior of each `ConvMode` was changed. In order to maintain the old behavior, we need to change `morpho_xx_inum` to use `ConvMode.SQUARE` which has the behavior that `ConvMode.HV` had previously.

Partially fixes https://github.com/Jaded-Encoding-Thaumaturgy/vs-exprtools/issues/23.