### PR TITLE
Rewrite & fix morpho module

### DIFF
--- a/vsmasktools/diff.py
+++ b/vsmasktools/diff.py
@@ -97,13 +97,13 @@ def credit_mask(
         ampl=ExLaplacian4, expand=4
     )
 
-    credit_mask = Morpho.erosion(credit_mask, 6)
+    credit_mask = Morpho.erosion(credit_mask, iterations=6)
     credit_mask = iterate(credit_mask, lambda x: x.std.Minimum().std.Maximum(), 8)
 
     if expand:
-        credit_mask = Morpho.dilation(credit_mask, expand)
+        credit_mask = Morpho.dilation(credit_mask, iterations=expand)
 
-    credit_mask = Morpho.inflate(credit_mask, 3)
+    credit_mask = Morpho.inflate(credit_mask, iterations=3)
 
     return credit_mask
 

--- a/vsmasktools/morpho.py
+++ b/vsmasktools/morpho.py
@@ -1,49 +1,55 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from itertools import zip_longest
-from math import floor, sqrt
-from typing import Any, Literal, Sequence, Tuple
+from math import sqrt
+from typing import Any, Literal, Sequence, cast
 
 from vsexprtools import ExprList, ExprOp, ExprToken, complexpr_available, norm_expr
 from vsrgtools import BlurMatrix
 from vstools import (
-    ConvMode, CustomIndexError, FuncExceptT, PlanesT, StrList, check_variable, copy_signature, core, fallback,
-    inject_self, interleave_arr, iterate, scale_value, to_arr, vs
+    ConvMode, CustomValueError, FuncExceptT, PlanesT, SpatialConvModeT, VSFunctionAllArgs,
+    copy_signature, core, fallback, inject_self, iterate, scale_mask, scale_value, to_arr, vs
 )
 
-from .types import Coordinates, MorphoFunc, XxpandMode
+from .types import Coordinates, XxpandMode
 
 __all__ = [
-    'Morpho', 'CoordsT',
+    'RadiusT',
+    'Morpho',
     'grow_mask'
 ]
 
-CoordsT = int | Tuple[int, ConvMode] | Sequence[int]
+RadiusT = int | tuple[int, SpatialConvModeT]
 
 
-def _minmax_method(  # type: ignore
-    self: Morpho, src: vs.VideoNode, thr: float | None = None,
-    coords: CoordsT | None = [1] * 8,
-    iterations: int = 1, multiply: float | None = None, planes: PlanesT = None,
-    *, func: FuncExceptT | None = None, **kwargs: Any
+def _morpho_method(
+    self: Morpho,
+    clip: vs.VideoNode,
+    radius: RadiusT = 1,
+    thr: float | None = None,
+    iterations: int = 1,
+    coords: Sequence[int] | None = None,
+    multiply: float | None = None,
+    planes: PlanesT = None,
+    *,
+    func: FuncExceptT | None = None,
+    **kwargs: Any
 ) -> vs.VideoNode:
-    ...
+    raise NotImplementedError
 
 
-def _morpho_method(  # type: ignore
-    self: Morpho, src: vs.VideoNode, radius: int = 1, planes: PlanesT = None, thr: float | None = None,
-    coords: CoordsT = 5, multiply: float | None = None,
-    *, func: FuncExceptT | None = None, **kwargs: Any
+def _xxpand_method(
+    self: Morpho,
+    clip: vs.VideoNode,
+    sw: int, sh: int | None = None,
+    mode: XxpandMode = XxpandMode.RECTANGLE,
+    thr: float | None = None,
+    planes: PlanesT = None,
+    *,
+    func: FuncExceptT | None = None,
+    **kwargs: Any
 ) -> vs.VideoNode:
-    ...
-
-
-def _morpho_method2(  # type: ignore
-    self: Morpho, clip: vs.VideoNode, sw: int, sh: int | None = None, mode: XxpandMode = XxpandMode.RECTANGLE,
-    thr: float | None = None, planes: PlanesT = None, *, func: FuncExceptT | None = None, **kwargs: Any
-) -> vs.VideoNode:
-    ...
+    raise NotImplementedError
 
 
 @dataclass

--- a/vsmasktools/morpho.py
+++ b/vsmasktools/morpho.py
@@ -52,38 +52,9 @@ def _xxpand_method(
     raise NotImplementedError
 
 
-@dataclass
 class Morpho:
-    planes: PlanesT = None
-    func: FuncExceptT | None = None
-    fast: bool | None = None
-
-    def __post_init__(self) -> None:
-        self._fast = fallback(self.fast, complexpr_available) and complexpr_available
-
-    def _check_params(
-        self, radius: int, thr: float | None, coords: CoordsT, planes: PlanesT, func: FuncExceptT
-    ) -> tuple[FuncExceptT, PlanesT]:
-        if radius < 1:
-            raise CustomIndexError('radius has to be greater than 0!', func, radius)
-
-        if isinstance(coords, (int, tuple)):
-            size = coords if isinstance(coords, int) else coords[0]
-
-            if size < 2:
-                raise CustomIndexError('when int or tuple, coords has to be greater than 1!', func, coords)
-
-            if not self._fast and size != 3:
-                raise CustomIndexError(
-                    'with fast=False or no akarin plugin, you must have coords=3!', func, coords
-                )
-        elif len(coords) != 8:
-            raise CustomIndexError('when a list, coords must contain exactly 8 numbers!', func, coords)
-
-        if thr is not None and thr < 0.0:
-            raise CustomIndexError('thr must be a positive number!', func, coords)
-
-        return self.func or func, self.planes if planes is None else planes
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        ...
 
     @classmethod
     def _morpho_xx_imum(

--- a/vsmasktools/morpho.py
+++ b/vsmasktools/morpho.py
@@ -264,187 +264,475 @@ class Morpho:
         return r, TupleExprList([expr])
 
     @inject_self
-    @copy_signature(_minmax_method)
     def maximum(
-        self, src: vs.VideoNode, thr: float | None = None, coords: CoordsT | None = None,
-        iterations: int = 1, multiply: float | None = None, planes: PlanesT = None,
-        *, func: FuncExceptT | None = None, **kwargs: Any
+        self,
+        clip: vs.VideoNode,
+        thr: float | None = None,
+        iterations: int = 1,
+        coords: Sequence[int] | None = None,
+        multiply: float | None = None,
+        planes: PlanesT = None,
+        *,
+        func: FuncExceptT | None = None,
+        **kwargs: Any
     ) -> vs.VideoNode:
-        return self.dilation(src, iterations, planes, thr, coords or ([1] * 8), multiply, func=func, **kwargs)
+        """
+        Replaces each pixel with the largest value in its 3x3 neighbourhood.
+        This operation is also known as dilation with a radius of 1.
+
+        :param clip:            Clip to process.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become greater than input + threshold
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the 3x3 neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly 8 numbers.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        return self.dilation(clip, 1, thr, iterations, coords, multiply, planes, func=func, **kwargs)
 
     @inject_self
-    @copy_signature(_minmax_method)
     def minimum(
-        self, src: vs.VideoNode, thr: float | None = None, coords: CoordsT | None = None,
-        iterations: int = 1, multiply: float | None = None, planes: PlanesT = None,
-        *, func: FuncExceptT | None = None, **kwargs: Any
+        self,
+        clip: vs.VideoNode,
+        thr: float | None = None,
+        iterations: int = 1,
+        coords: Sequence[int] | None = None,
+        multiply: float | None = None,
+        planes: PlanesT = None,
+        *,
+        func: FuncExceptT | None = None,
+        **kwargs: Any
     ) -> vs.VideoNode:
-        return self.erosion(src, iterations, planes, thr, coords or ([1] * 8), multiply, func=func, **kwargs)
+        """
+        Replaces each pixel with the smallest value in its 3x3 neighbourhood.
+        This operation is also known as erosion with a radius of 1.
+
+        :param clip:            Clip to process.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the 3x3 neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value. This must contain exactly 8 numbers.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        return self.erosion(clip, 1, thr, iterations, coords, multiply, planes, func=func, **kwargs)
 
     @inject_self
-    def inflate(
-        self: Morpho, src: vs.VideoNode, radius: int = 1, planes: PlanesT = None, thr: float | None = None,
-        iterations: int = 1, multiply: float | None = None, *, func: FuncExceptT | None = None
-    ) -> vs.VideoNode:
-        for _ in range(iterations):
-            src = self._xxflate(True, src, radius, planes, thr, multiply, func=func or self.inflate)
-        return src
+    @copy_signature(_morpho_method)
+    def inflate(self, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        Replaces each pixel with the average of the (radius * 2 + 1) ** 2 - 1 pixels
+        in its (radius * 2 + 1)x(radius * 2 + 1) neighbourhood, but only if that average
+        is greater than the center pixel.
+
+        A radius of 1 will replace each pixel with the average of the 8 pixels in its 3x3 neighbourhood.
+        A radius of 2 will replace each pixel with the average of the 24 pixels in its 5x5 neighbourhood.
+
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become greater than input + thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        return self._xxflate(*args, func=func or self.inflate, inflate=True, **kwargs)
 
     @inject_self
-    def deflate(
-        self: Morpho, src: vs.VideoNode, radius: int = 1, planes: PlanesT = None, thr: float | None = None,
-        iterations: int = 1, multiply: float | None = None, *, func: FuncExceptT | None = None
-    ) -> vs.VideoNode:
-        for _ in range(iterations):
-            src = self._xxflate(False, src, radius, planes, thr, multiply, func=func or self.deflate)
-        return src
+    @copy_signature(_morpho_method)
+    def deflate(self, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        Replaces each pixel with the average of the (radius * 2 + 1) ** 2 - 1 pixels
+        in its (radius * 2 + 1)x(radius * 2 + 1) neighbourhood, but only if that average
+        is less than the center pixel.
+
+        A radius of 1 will replace each pixel with the average of the 8 pixels in its 3x3 neighbourhood.
+        A radius of 2 will replace each pixel with the average of the 24 pixels in its 5x5 neighbourhood.
+
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        return self._xxflate(*args, func=func or self.deflate, inflate=False, **kwargs)
 
     @inject_self
     @copy_signature(_morpho_method)
     def dilation(self, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        Replaces each pixel with the largest value in its (radius * 2 + 1)x(radius * 2 + 1) neighbourhood.
+
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
         return self._mm_func(*args, func=func or self.dilation, mm_func=core.std.Maximum, op=ExprOp.MAX, **kwargs)
 
     @inject_self
     @copy_signature(_morpho_method)
     def erosion(self, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        Replaces each pixel with the smallest value in its (radius * 2 + 1)x(radius * 2 + 1) neighbourhood.
+
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
         return self._mm_func(*args, func=func or self.erosion, mm_func=core.std.Minimum, op=ExprOp.MIN, **kwargs)
 
     @inject_self
-    @copy_signature(_morpho_method2)
+    @copy_signature(_xxpand_method)
     def expand(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
-        return self.xxpand_transform(clip, ExprOp.MAX, *args, func=func, **kwargs)
+        """
+        Replaces multiple times each pixel with the largest value in its 3x3 neighbourhood.
+        Specifying a mode will allow custom growing mode.
+
+        :param clip:            Clip to process.
+        :param sw:              Number of horizontal iterations.
+        :param sh:              Number of vertical iterations.
+        :param mode:            Specifies the expand mode shape.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param planes:          Which plane to process.
+        """
+        return self._xxpand_transform(clip, *args, op=ExprOp.MAX, func=func or self.expand, **kwargs)
 
     @inject_self
-    @copy_signature(_morpho_method2)
+    @copy_signature(_xxpand_method)
     def inpand(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
-        return self.xxpand_transform(clip, ExprOp.MIN, *args, func=func, **kwargs)
+        """
+        Replaces multiple times each pixel with the smallest value in its 3x3 neighbourhood.
+        Specifying a mode will allow custom growing mode.
+
+        :param clip:            Clip to process.
+        :param sw:              Number of horizontal iterations.
+        :param sh:              Number of vertical iterations.
+        :param mode:            Specifies the expand mode shape.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param planes:          Which plane to process.
+        """
+        return self._xxpand_transform(clip, *args, op=ExprOp.MIN, func=func or self.inpand, **kwargs)
 
     @inject_self
     @copy_signature(_morpho_method)
-    def closing(self, src: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+    def closing(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        A closing is an dilation followed by an erosion.
+
+        :param clip:            Clip to process
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
         func = func or self.closing
 
-        dilated = self.dilation(src, *args, func=func, **kwargs)
+        dilated = self.dilation(clip, *args, func=func, **kwargs)
         eroded = self.erosion(dilated, *args, func=func, **kwargs)
 
         return eroded
 
     @inject_self
     @copy_signature(_morpho_method)
-    def opening(self, src: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
-        func = func or self.closing
+    def opening(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        An opening is an erosion followed by an dilation.
 
-        eroded = self.erosion(src, *args, func=func, **kwargs)
+        :param clip:            Clip to process
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        func = func or self.opening
+
+        eroded = self.erosion(clip, *args, func=func, **kwargs)
         dilated = self.dilation(eroded, *args, func=func, **kwargs)
 
         return dilated
 
     @inject_self
-    def gradient(
-        self, src: vs.VideoNode, radius: int = 1, planes: PlanesT = None, thr: float | None = None,
-        coords: CoordsT = 5, multiply: float | None = None, *, func: FuncExceptT | None = None, **kwargs: Any
-    ) -> vs.VideoNode:
-        func, planes = self._check_params(radius, thr, coords, planes, func or self.gradient)
+    @copy_signature(_morpho_method)
+    def gradient(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        A morphological gradient is the difference between a dilation and erosion.
 
-        if radius == 1 and self._fast:
-            return norm_expr(
-                src, '{dilated} {eroded} - {multiply}', planes,
-                dilated=self._morpho_xx_imum(src, thr, ExprOp.MAX, coords, None, True),
-                eroded=self._morpho_xx_imum(src, thr, ExprOp.MIN, coords, None, True),
-                multiply='' if multiply is None else f'{multiply} *'
-            )
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        func = func or self.gradient
 
-        eroded = self.erosion(src, radius, planes, thr, coords, multiply, func=func, **kwargs)
-        dilated = self.dilation(src, radius, planes, thr, coords, multiply, func=func, **kwargs)
+        eroded = self.erosion(clip, *args, func=func, **kwargs)
+        dilated = self.dilation(clip, *args, func=func, **kwargs)
 
-        return norm_expr([dilated, eroded], 'x y -', planes)
+        return norm_expr(
+            [dilated, eroded], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
+        )
 
     @inject_self
     @copy_signature(_morpho_method)
-    def top_hat(self, src: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
-        opened = self.opening(src, *args, func=func or self.top_hat, **kwargs)
+    def top_hat(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        A top hat or a white hat is the difference of the original clip and the opening.
 
-        return norm_expr([src, opened], 'x y -', kwargs.get('planes', args[1] if len(args) > 1 else None))
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        func = func or self.top_hat
+
+        opened = self.opening(clip, *args, func=func, **kwargs)
+
+        return norm_expr(
+            [clip, opened], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
+        )
 
     @inject_self
     @copy_signature(_morpho_method)
-    def black_hat(self, src: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
-        closed = self.closing(src, *args, func=func or self.black_hat, **kwargs)
+    def bottom_hat(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        A bottom hat or a black hat is the difference of the closing and the original clip.
 
-        return norm_expr([closed, src], 'x y -', kwargs.get('planes', args[1] if len(args) > 1 else None))
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        func = func or self.bottom_hat
+
+        closed = self.closing(clip, *args, func=func, **kwargs)
+
+        return norm_expr(
+            [closed, clip], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
+        )
+
 
     @inject_self
-    def outer_hat(
-        self, src: vs.VideoNode, radius: int = 1, planes: PlanesT = None, thr: float | None = None,
-        coords: CoordsT = 5, multiply: float | None = None, *, func: FuncExceptT | None = None, **kwargs: Any
-    ) -> vs.VideoNode:
-        func, planes = self._check_params(radius, thr, coords, planes, func or self.outer_hat)
+    @copy_signature(_morpho_method)
+    def outer_hat(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        An outer hat is the difference of the dilation and the original clip.
 
-        if radius == 1 and self._fast:
-            return norm_expr(
-                src, '{dilated} {multiply} x -', planes,
-                dilated=self._morpho_xx_imum(src, thr, ExprOp.MAX, coords, None, True),
-                multiply='' if multiply is None else f'{multiply} *'
-            )
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        func = func or self.outer_hat
 
-        dilated = self.dilation(src, radius, planes, thr, coords, multiply, func=func, **kwargs)
+        dilated = self.dilation(clip, *args, func=func, **kwargs)
 
-        return norm_expr([dilated, src], 'x y -', planes)
+        return norm_expr(
+            [dilated, clip], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
+        )
 
     @inject_self
-    def inner_hat(
-        self, src: vs.VideoNode, radius: int = 1, planes: PlanesT = None, thr: float | None = None,
-        coords: CoordsT = 5, multiply: float | None = None, *, func: FuncExceptT | None = None, **kwargs: Any
-    ) -> vs.VideoNode:
-        func, planes = self._check_params(radius, thr, coords, planes, func or self.inner_hat)
+    def inner_hat(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
+        """
+        An inner hat is the difference of the original clip and the erosion.
 
-        if radius == 1 and self._fast:
-            return norm_expr(
-                src, '{eroded} {multiply} x -', planes,
-                eroded=self._morpho_xx_imum(src, thr, ExprOp.MIN, coords),
-                multiply='' if multiply is None else f'{multiply} *'
-            )
+        :param clip:            Clip to process.
+        :param radius:          A single integer specifies the size of the square matrix.
+                                A tuple of an integer and a ConvMode allows specification
+                                of the matrix type dimension as well.
+        :param thr:             Threshold (32-bit scale) to limit how much pixels are changed.
+                                Output pixels will not become less than input - thr.
+                                The default is no limit.
+        :param iterations:      Number of times to execute the function.
+        :param coords:          Specifies which pixels from the neighbourhood are considered.
+                                If an element of this array is 0, the corresponding pixel is not considered
+                                when finding the maximum value.
+                                This must contain exactly (radius * 2 + 1) ** 2 - 1 numbers eg. 8, 24, 48...
+                                When specified, this parameter takes precedence over radius.
+        :param multiply:        Optional multiplier of the final value.
+        :param planes:          Which plane to process.
+        """
+        func = func or self.inner_hat
 
-        eroded = self.erosion(src, radius, planes, thr, coords, multiply, func=func, **kwargs)
+        eroded = self.erosion(clip, *args, func=func, **kwargs)
 
-        return norm_expr([src, eroded], 'x y -', planes)
+        return norm_expr(
+            [clip, eroded], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
+        )
 
     @inject_self
     def binarize(
-        self, src: vs.VideoNode, midthr: float | list[float] | None = None,
-        lowval: float | list[float] | None = None, highval: float | list[float] | None = None,
+        self,
+        clip: vs.VideoNode,
+        midthr: float | list[float] | None = None,
+        lowval: float | list[float] | None = None,
+        highval: float | list[float] | None = None,
         planes: PlanesT = None
     ) -> vs.VideoNode:
+        """
+        Turns every pixel in the image into either lowval, if it's below midthr, or highval, otherwise.
+
+        :param clip:            Clip to process.
+        :param midthr:          Defaults to the middle point of range allowed by the format.
+                                Can be specified for each plane individually.
+        :param lowval:          Value given to pixels that are below threshold.
+                                Can be specified for each plane individually.
+                                Defaults to the lower bound of the format.
+        :param highval:         Value given to pixels that are greater than or equal to threshold.
+                                Defaults to the maximum value allowed by the format.
+                                Can be specified for each plane individually.
+                                Defaults to the upper bound of the format.
+        :param planes:          Specifies which planes will be processed.
+                                Any unprocessed planes will be simply copied.
+        """
         midthr, lowval, highval = (
             thr and list(
-                scale_value(t, 32, src)
-                for i, t in enumerate(to_arr(thr))
+                scale_value(t, 32, clip)
+                for t in to_arr(thr)
             ) for thr in (midthr, lowval, highval)
         )
 
-        return src.std.Binarize(midthr, lowval, highval, planes)
+        return core.std.Binarize(clip, midthr, lowval, highval, planes)
 
 
 def grow_mask(
-    mask: vs.VideoNode, radius: int = 1, multiply: float = 1.0,
-    planes: PlanesT = None, coords: CoordsT = 5, thr: float | None = None,
-    *, func: FuncExceptT | None = None, **kwargs: Any
+    clip: vs.VideoNode,
+    radius: RadiusT = 1,
+    thr: float | None = None,
+    iterations: int = 1,
+    coords: Sequence[int] | None = None,
+    multiply: float | None = None,
+    planes: PlanesT = None,
+    *,
+    func: FuncExceptT | None = None,
+    **kwargs: Any
 ) -> vs.VideoNode:
     func = func or grow_mask
 
-    assert check_variable(mask, func)
+    morpho = Morpho()
 
-    morpho = Morpho(planes, func)
-
-    kwargs.update(thr=thr, coords=coords)
-
-    closed = morpho.closing(mask, **kwargs)
-    dilated = morpho.dilation(closed, **kwargs)
-    outer = morpho.outer_hat(dilated, radius, **kwargs)
+    closed = morpho.closing(clip, radius, thr, iterations, coords, multiply, planes, func=func, **kwargs)
+    dilated = morpho.dilation(closed, radius, thr, iterations, coords, multiply, planes, func=func, **kwargs)
+    outer = morpho.outer_hat(dilated, radius, thr, iterations, coords, multiply, planes, func=func, **kwargs)
 
     blurred = BlurMatrix.BINOMIAL()(outer, planes=planes)
 
-    if multiply != 1.0:
+    if multiply:
         return blurred.std.Expr(f'x {multiply} *')
 
     return blurred

--- a/vsmasktools/morpho.py
+++ b/vsmasktools/morpho.py
@@ -585,6 +585,11 @@ class Morpho:
             [clip, opened], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
         )
 
+    @copy_signature(top_hat)
+    @inject_self
+    def white_hate(self, *args: Any, **kwargs: Any) -> vs.VideoNode:
+        return self.top_hat(*args, **dict(func=self.white_hate) | kwargs)
+
     @inject_self
     @copy_signature(_morpho_method)
     def bottom_hat(self, clip: vs.VideoNode, *args: Any, func: FuncExceptT | None = None, **kwargs: Any) -> vs.VideoNode:
@@ -615,6 +620,10 @@ class Morpho:
             [closed, clip], 'x y -', kwargs.get('planes', args[5] if len(args) > 5 else None), func=func
         )
 
+    @copy_signature(bottom_hat)
+    @inject_self
+    def black_hat(self, *args: Any, **kwargs: Any) -> vs.VideoNode:
+        return self.top_hat(*args, **dict(func=self.black_hat) | kwargs)
 
     @inject_self
     @copy_signature(_morpho_method)

--- a/vsmasktools/types.py
+++ b/vsmasktools/types.py
@@ -1,27 +1,18 @@
 from __future__ import annotations
 
-from typing import Callable, Protocol, Union
+from typing import Callable, Union
 
-from vstools import CustomEnum, PlanesT, SingleOrArrOpt, vs
+from vstools import CustomEnum, vs
 
 from .abstract import GeneralMask
 from .edge._abstract import EdgeDetectT, RidgeDetectT
 
 __all__ = [
-    'MorphoFunc',
     'XxpandMode',
     'Coordinates',
 
     'GenericMaskT'
 ]
-
-
-class MorphoFunc(Protocol):
-    def __call__(
-        self, clip: vs.VideoNode, planes: PlanesT = ...,
-        threshold: float | None = ..., coordinates: SingleOrArrOpt[int] = ...
-    ) -> vs.VideoNode:
-        ...
 
 
 class XxpandMode(CustomEnum):


### PR DESCRIPTION
This is a complete rewrite of the Morpho module since it has bugs, obscure parameter names and weird behavior.
Also there is now basic docstring on every function.